### PR TITLE
Fix locals assignment when given a `locals` local

### DIFF
--- a/lib/tilt/template.rb
+++ b/lib/tilt/template.rb
@@ -179,6 +179,11 @@ module Tilt
       locals_keys = locals.keys
       locals_keys.sort!{|x, y| x.to_s <=> y.to_s}
 
+      # If there is a locals key itself named `locals`, put it last so it
+      # doesn't clobber the assignment of other locals from the same-named
+      # local variable in `#compile_template_method`
+      locals_keys.delete(:locals) and locals_keys.push(:locals) if locals_keys.include?(:locals)
+
       case scope
       when Object
         scope_class = Module === scope ? scope : scope.class

--- a/test/tilt_template_test.rb
+++ b/test/tilt_template_test.rb
@@ -149,6 +149,14 @@ describe "tilt/template" do
     assert inst.prepared?
   end
 
+  it "template_source with locals including 'locals'" do
+    # Ensure that a locals hash value named `locals` doesn't clobber the ability to assign other
+    # locals that follow it in sorted order
+    inst = _SourceGeneratingMockTemplate.new { |t| 'Hey #{name}!' }
+    assert_equal "Hey Jane!", inst.render(Object.new, :locals => {other: 'stuff here'}, :name => 'Jane')
+    assert inst.prepared?
+  end
+
   it "template with compiled_path" do
     Dir.mktmpdir('tilt') do |dir|
       base = File.join(dir, 'template')


### PR DESCRIPTION
👋🏼 Hi @jeremyevans! I’m a big Tilt user through, as you might expect, hanami-view.

When we render Tilt templates in hanami-view, we largely avoid using the `locals` argument, instead providing a `scope` object that provides access to everything the user needs inside their template. However, a little while ago we noticed that a `#locals` method on that scope object wasn't implicitly accessible inside the templates, requiring `self.locals` instead of just `locals`. This turned out to be because `locals` is in fact a _local variable_ thanks to the method that Tilt generates for each template, where `locals` is the method's one and only argument.

We solved this issue in https://github.com/hanami/view/pull/208, but providing a locals hash of `{locals: some_hash}` to Tilt's `Template#render`.

This has worked smoothly since then, but I've just discovered an edge case: Tilt's `BuilderTemplate` [provides and then merges in](https://github.com/jeremyevans/tilt/blob/7907334d43afb53d37122470e5b346d235ad40c2/lib/tilt/builder.rb#L19) an `:xml` local so that the template code can use an `xml` local variable to build up the desired XML structure.

However, because Tilt [orders its locals alphabetically](https://github.com/jeremyevans/tilt/blob/7907334d43afb53d37122470e5b346d235ad40c2/lib/tilt/template.rb#L179-L180) before then [assigning each local to a local variable](https://github.com/jeremyevans/tilt/blob/7907334d43afb53d37122470e5b346d235ad40c2/lib/tilt/template.rb#L267), this means that we end up with generated code that looks like this:

```
def __generated_template_method_name__(locals)
  locals = locals[:locals]
  xml = locals[:xml]
```

Because our `locals[:locals]` is also a hash, this doesn't immediately error, but it _does_ result in `xml` in the line below being assigned `nil`, because while it did exist in the _original_ `locals` variable, it _doesn't_ exist in the new locals variable that is reassigned in the line just above.

To fix this, in this PR I've:

1. Added a test to make sure we're not clobbering locals if we provide a local called `:locals`
2. Added a proposed fix that happens at the time of `locals_keys` sorting: at this time, look for a `:locals` locals key, and if present, take it out of the sorted `locals_keys` and then push it onto the end. In this way, the `:locals` local is handled very last, by which point the `locals` local variable reassignment will be safe to do.

Of course there are plenty of other ways we could tackle this. One thought I had was to change the argument name for the generated template method from `locals` to `__locals` or something similar. However, I thought this might be a more user-disruptive change: this `locals` name has been around since the earliest days of Tilt, and vanilla Tilt users may be depending on it in various ways.

I'm happy to take your advice on how you think we can best fix this 😄 

Also, is this the right place to be sending this PR? I can see you're actively sprucing up Tilt here, and figured this would be the repo from which future releases are made.

Thanks!