### PR TITLE
Support Commonmarker v1 api

### DIFF
--- a/.ci.gemfile
+++ b/.ci.gemfile
@@ -74,7 +74,13 @@ platform :ruby do
   gem 'rinku' # dependency for wikicloth for handling links
 
   gem 'RedCloth'
-  gem 'commonmarker', '< 1'
+
+  if ENV['LATEST_COMMONMARKER'] == 'yes'
+    gem 'commonmarker'
+  else
+    gem 'commonmarker', '< 1'
+  end
+
   gem 'rdiscount', '>= 2.1.6'
   gem 'redcarpet'
   gem 'yajl-ruby'

--- a/.ci.gemfile
+++ b/.ci.gemfile
@@ -74,12 +74,7 @@ platform :ruby do
   gem 'rinku' # dependency for wikicloth for handling links
 
   gem 'RedCloth'
-
-  if ENV['LATEST_COMMONMARKER'] == 'yes'
-    gem 'commonmarker'
-  else
-    gem 'commonmarker', '< 1'
-  end
+  gem 'commonmarker'
 
   gem 'rdiscount', '>= 2.1.6'
   gem 'redcarpet'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,19 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, jruby-9.1, jruby-9.2, jruby-9.3, jruby-9.4 ]
+        latest_commonmarker: ["", "yes"]
+        include:
+          - ruby: "3.1"
+            latest_commonmarker: "yes"
+          - ruby: "3.2"
+            latest_commonmarker: "yes"
+          - ruby: "3.3"
+            latest_commonmarker: "yes"
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile
       COFFEE_SCRIPT: use
+      LATEST_COMMONMARKER: ${{ matrix.latest_commonmarker }}
     steps:
     - uses: actions/checkout@v4
     # WikiCloth needs IDN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, jruby-9.1, jruby-9.2, jruby-9.3, jruby-9.4 ]
-        latest_commonmarker: ["", "yes"]
-        include:
-          - ruby: "3.1"
-            latest_commonmarker: "yes"
-          - ruby: "3.2"
-            latest_commonmarker: "yes"
-          - ruby: "3.3"
-            latest_commonmarker: "yes"
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile
       COFFEE_SCRIPT: use
-      LATEST_COMMONMARKER: ${{ matrix.latest_commonmarker }}
     steps:
     - uses: actions/checkout@v4
     # WikiCloth needs IDN

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -4,47 +4,47 @@ require 'commonmarker'
 
 module Tilt
   class CommonMarkerTemplate < StaticTemplate
-    def prepare
-      aliases = {
-        :smartypants => :SMART
-      }.freeze
-      parse_opts = [
-        :FOOTNOTES,
-        :LIBERAL_HTML_TAG,
-        :SMART,
-        :smartypants,
-        :STRIKETHROUGH_DOUBLE_TILDE,
-        :UNSAFE,
-        :VALIDATE_UTF8,
-      ].freeze
-      render_opts = [
-        :FOOTNOTES,
-        :FULL_INFO_STRING,
-        :GITHUB_PRE_LANG,
-        :HARDBREAKS,
-        :NOBREAKS,
-        :SAFE, # Removed in v0.18.0 (2018-10-17)
-        :SOURCEPOS,
-        :TABLE_PREFER_STYLE_ATTRIBUTES,
-        :UNSAFE,
-      ].freeze
-      exts = [
-        :autolink,
-        :strikethrough,
-        :table,
-        :tagfilter,
-        :tasklist,
-      ].freeze
+    ALIASES = {
+      :smartypants => :SMART
+    }.freeze
+    PARSE_OPTS = [
+      :FOOTNOTES,
+      :LIBERAL_HTML_TAG,
+      :SMART,
+      :smartypants,
+      :STRIKETHROUGH_DOUBLE_TILDE,
+      :UNSAFE,
+      :VALIDATE_UTF8,
+    ].freeze
+    RENDER_OPTS = [
+      :FOOTNOTES,
+      :FULL_INFO_STRING,
+      :GITHUB_PRE_LANG,
+      :HARDBREAKS,
+      :NOBREAKS,
+      :SAFE, # Removed in v0.18.0 (2018-10-17)
+      :SOURCEPOS,
+      :TABLE_PREFER_STYLE_ATTRIBUTES,
+      :UNSAFE,
+    ].freeze
+    EXTS = [
+      :autolink,
+      :strikethrough,
+      :table,
+      :tagfilter,
+      :tasklist,
+    ].freeze
 
-      extensions = exts.select do |extension|
+    def prepare
+      extensions = EXTS.select do |extension|
         @options[extension]
       end
 
-      parse_options, render_options = [parse_opts, render_opts].map do |opts|
+      parse_options, render_options = [PARSE_OPTS, RENDER_OPTS].map do |opts|
         opts = opts.select do |option|
           @options[option]
         end.map! do |option|
-          aliases[option] || option
+          ALIASES[option] || option
         end
 
         opts = :DEFAULT unless opts.any?

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -2,101 +2,88 @@
 require_relative 'template'
 require 'commonmarker'
 
-module Tilt
-  class CommonMarkerTemplate < StaticTemplate
-    ALIASES = {
-      :smartypants => :SMART
-    }.freeze
-    PARSE_OPTS = [
-      :FOOTNOTES,
-      :LIBERAL_HTML_TAG,
-      :SMART,
-      :smartypants,
-      :STRIKETHROUGH_DOUBLE_TILDE,
-      :UNSAFE,
-      :VALIDATE_UTF8,
-    ].freeze
-    RENDER_OPTS = [
-      :FOOTNOTES,
-      :FULL_INFO_STRING,
-      :GITHUB_PRE_LANG,
-      :HARDBREAKS,
-      :NOBREAKS,
-      :SAFE, # Removed in v0.18.0 (2018-10-17)
-      :SOURCEPOS,
-      :TABLE_PREFER_STYLE_ATTRIBUTES,
-      :UNSAFE,
-    ].freeze
-    EXTS = [
-      :autolink,
-      :strikethrough,
-      :table,
-      :tagfilter,
-      :tasklist,
-    ].freeze
+if defined?(::Commonmarker)
+  parse_opts = [
+    :smart,
+    :default_info_string,
+  ].freeze
+  render_opts = [
+    :hardbreaks,
+    :github_pre_lang,
+    :width,
+    :unsafe,
+    :escape,
+    :sourcepos,
+  ].freeze
+  exts = [
+    :strikethrough,
+    :tagfilter,
+    :table,
+    :autolink,
+    :tasklist,
+    :superscript,
+    :header_ids,
+    :footnotes,
+    :description_lists,
+    :front_matter_delimiter,
+    :shortcodes,
+  ].freeze
 
-    V1_PARSE_OPTS = [
-      :smart,
-      :default_info_string,
-    ].freeze
-    V1_RENDER_OPTS = [
-      :hardbreaks,
-      :github_pre_lang,
-      :width,
-      :unsafe,
-      :escape,
-      :sourcepos,
-    ].freeze
-    V1_EXTS = [
-      :strikethrough,
-      :tagfilter,
-      :table,
-      :autolink,
-      :tasklist,
-      :superscript,
-      :header_ids,
-      :footnotes,
-      :description_lists,
-      :front_matter_delimiter,
-      :shortcodes,
-    ].freeze
+  Tilt::CommonMarkerTemplate = Tilt::StaticTemplate.subclass do
+    parse_options = @options.select { |key, _| parse_opts.include?(key) }
+    render_options = @options.select { |key, _| render_opts.include?(key) }
+    extensions = @options.select { |key, _| exts.include?(key) }
 
-    def prepare
-      if commonmaker_v1_or_later?
-        prepare_v1
-      else
-        prepare_pre
-      end
+    Commonmarker.to_html(@data, options: { parse: parse_options, render: render_options, extension: extensions })
+  end
+else
+  aliases = {
+    :smartypants => :SMART
+  }.freeze
+  parse_opts = [
+    :FOOTNOTES,
+    :LIBERAL_HTML_TAG,
+    :SMART,
+    :smartypants,
+    :STRIKETHROUGH_DOUBLE_TILDE,
+    :UNSAFE,
+    :VALIDATE_UTF8,
+  ].freeze
+  render_opts = [
+    :FOOTNOTES,
+    :FULL_INFO_STRING,
+    :GITHUB_PRE_LANG,
+    :HARDBREAKS,
+    :NOBREAKS,
+    :SAFE, # Removed in v0.18.0 (2018-10-17)
+    :SOURCEPOS,
+    :TABLE_PREFER_STYLE_ATTRIBUTES,
+    :UNSAFE,
+  ].freeze
+  exts = [
+    :autolink,
+    :strikethrough,
+    :table,
+    :tagfilter,
+    :tasklist,
+  ].freeze
+
+  Tilt::CommonMarkerTemplate = Tilt::StaticTemplate.subclass do
+    extensions = exts.select do |extension|
+      @options[extension]
     end
 
-    private def prepare_pre
-      extensions = EXTS.select do |extension|
-        @options[extension]
-      end
-
-      parse_options, render_options = [PARSE_OPTS, RENDER_OPTS].map do |opts|
-        opts = opts.select do |option|
-          @options[option]
-        end.map! do |option|
-          ALIASES[option] || option
-        end
-
-        opts = :DEFAULT unless opts.any?
-        opts
+    parse_options, render_options = [parse_opts, render_opts].map do |opts|
+      opts = opts.select do |option|
+        @options[option]
+      end.map! do |option|
+        aliases[option] || option
       end
 
-      @output = CommonMarker.render_doc(@data, parse_options, extensions).to_html(render_options, extensions)
+      opts = :DEFAULT unless opts.any?
+      opts
     end
 
-    private def prepare_v1
-      parse_options = @options.select { |key, _| V1_PARSE_OPTS.include?(key) }
-      render_options = @options.select { |key, _| V1_RENDER_OPTS.include?(key) }
-      extensions = @options.select { |key, _| V1_EXTS.include?(key) }
-      @output = Commonmarker.to_html(@data, options: { parse: parse_options, render: render_options, extension: extensions })
-    end
-
-    private def commonmaker_v1_or_later?
-      defined?(::Commonmarker) ? true : false
-    end
+    CommonMarker.render_doc(@data, parse_options, extensions).to_html(render_options, extensions)
   end
 end

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -3,6 +3,9 @@ require_relative 'template'
 require 'commonmarker'
 
 if defined?(::Commonmarker)
+  aliases = {
+    :smartypants => :smart
+  }.freeze
   parse_opts = [
     :smart,
     :default_info_string,
@@ -30,9 +33,10 @@ if defined?(::Commonmarker)
   ].freeze
 
   Tilt::CommonMarkerTemplate = Tilt::StaticTemplate.subclass do
-    parse_options = @options.select { |key, _| parse_opts.include?(key) }
-    render_options = @options.select { |key, _| render_opts.include?(key) }
-    extensions = @options.select { |key, _| exts.include?(key) }
+    parse_options = @options.select { |key, _| parse_opts.include?(key.downcase) }.transform_keys(&:downcase)
+    parse_options.merge!(@options.select { |key, _| aliases.has_key?(key) }.transform_keys { |key| aliases[key] })
+    render_options = @options.select { |key, _| render_opts.include?(key.downcase) }.transform_keys(&:downcase)
+    extensions = @options.select { |key, _| exts.include?(key) }.transform_keys(&:downcase)
 
     Commonmarker.to_html(@data, options: { parse: parse_options, render: render_options, extension: extensions })
   end

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -2,53 +2,56 @@
 require_relative 'template'
 require 'commonmarker'
 
-aliases = {
-  :smartypants => :SMART
-}.freeze
-parse_opts = [
-  :FOOTNOTES,
-  :LIBERAL_HTML_TAG,
-  :SMART,
-  :smartypants,
-  :STRIKETHROUGH_DOUBLE_TILDE,
-  :UNSAFE,
-  :VALIDATE_UTF8,
-].freeze
-render_opts = [
-  :FOOTNOTES,
-  :FULL_INFO_STRING,
-  :GITHUB_PRE_LANG,
-  :HARDBREAKS,
-  :NOBREAKS,
-  :SAFE, # Removed in v0.18.0 (2018-10-17)
-  :SOURCEPOS,
-  :TABLE_PREFER_STYLE_ATTRIBUTES,
-  :UNSAFE,
-].freeze
-exts = [
-  :autolink,
-  :strikethrough,
-  :table,
-  :tagfilter,
-  :tasklist,
-].freeze
+module Tilt
+  class CommonMarkerTemplate < StaticTemplate
+    def prepare
+      aliases = {
+        :smartypants => :SMART
+      }.freeze
+      parse_opts = [
+        :FOOTNOTES,
+        :LIBERAL_HTML_TAG,
+        :SMART,
+        :smartypants,
+        :STRIKETHROUGH_DOUBLE_TILDE,
+        :UNSAFE,
+        :VALIDATE_UTF8,
+      ].freeze
+      render_opts = [
+        :FOOTNOTES,
+        :FULL_INFO_STRING,
+        :GITHUB_PRE_LANG,
+        :HARDBREAKS,
+        :NOBREAKS,
+        :SAFE, # Removed in v0.18.0 (2018-10-17)
+        :SOURCEPOS,
+        :TABLE_PREFER_STYLE_ATTRIBUTES,
+        :UNSAFE,
+      ].freeze
+      exts = [
+        :autolink,
+        :strikethrough,
+        :table,
+        :tagfilter,
+        :tasklist,
+      ].freeze
 
+      extensions = exts.select do |extension|
+        @options[extension]
+      end
 
-Tilt::CommonMarkerTemplate = Tilt::StaticTemplate.subclass do
-  extensions = exts.select do |extension|
-    @options[extension]
-  end
+      parse_options, render_options = [parse_opts, render_opts].map do |opts|
+        opts = opts.select do |option|
+          @options[option]
+        end.map! do |option|
+          aliases[option] || option
+        end
 
-  parse_options, render_options = [parse_opts, render_opts].map do |opts|
-    opts = opts.select do |option|
-      @options[option]
-    end.map! do |option|
-      aliases[option] || option
+        opts = :DEFAULT unless opts.any?
+        opts
+      end
+
+      @output = CommonMarker.render_doc(@data, parse_options, extensions).to_html(render_options, extensions)
     end
-
-    opts = :DEFAULT unless opts.any?
-    opts
   end
-
-  CommonMarker.render_doc(@data, parse_options, extensions).to_html(render_options, extensions)
 end

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -36,6 +36,10 @@ module Tilt
     ].freeze
 
     def prepare
+      prepare_pre
+    end
+
+    private def prepare_pre
       extensions = EXTS.select do |extension|
         @options[extension]
       end

--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -35,8 +35,38 @@ module Tilt
       :tasklist,
     ].freeze
 
+    V1_PARSE_OPTS = [
+      :smart,
+      :default_info_string,
+    ].freeze
+    V1_RENDER_OPTS = [
+      :hardbreaks,
+      :github_pre_lang,
+      :width,
+      :unsafe,
+      :escape,
+      :sourcepos,
+    ].freeze
+    V1_EXTS = [
+      :strikethrough,
+      :tagfilter,
+      :table,
+      :autolink,
+      :tasklist,
+      :superscript,
+      :header_ids,
+      :footnotes,
+      :description_lists,
+      :front_matter_delimiter,
+      :shortcodes,
+    ].freeze
+
     def prepare
-      prepare_pre
+      if commonmaker_v1_or_later?
+        prepare_v1
+      else
+        prepare_pre
+      end
     end
 
     private def prepare_pre
@@ -56,6 +86,17 @@ module Tilt
       end
 
       @output = CommonMarker.render_doc(@data, parse_options, extensions).to_html(render_options, extensions)
+    end
+
+    private def prepare_v1
+      parse_options = @options.select { |key, _| V1_PARSE_OPTS.include?(key) }
+      render_options = @options.select { |key, _| V1_RENDER_OPTS.include?(key) }
+      extensions = @options.select { |key, _| V1_EXTS.include?(key) }
+      @output = Commonmarker.to_html(@data, options: { parse: parse_options, render: render_options, extension: extensions })
+    end
+
+    private def commonmaker_v1_or_later?
+      defined?(::Commonmarker) ? true : false
     end
   end
 end

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -78,13 +78,11 @@ EXPECTED_HTML
 
     it "render markdown with custom prefixed-header id" do
       template = Tilt::CommonMarkerTemplate.new(header_ids: "prefix-") do |t|
-        <<~MARKDOWN
-          # Foo
-        MARKDOWN
+        "# Foo"
       end
-      expected = <<~HTML
-        <h1><a href="#foo" aria-hidden="true" class="anchor" id="prefix-foo"></a>Foo</h1>
-      HTML
+      expected = <<HTML
+<h1><a href="#foo" aria-hidden="true" class="anchor" id="prefix-foo"></a>Foo</h1>
+HTML
       assert_match(expected, template.render)
     end
   end

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -1,26 +1,27 @@
 require_relative 'test_helper'
 
 checked_describe 'tilt/commonmarker' do
-  it "preparing and evaluating templates on #render" do
-    template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-    assert_equal "<h1>Hello World!</h1>\n", template.render
-  end
-
-  it "can be rendered more than once" do
-    template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-    3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
-  end
-
-  it "smartypants when :smartypants is set" do
-    template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
-      "OKAY -- 'Smarty Pants'"
+  if ENV['LATEST_COMMONMARKER'] == 'yes'
+    it "preparing and evaluating templates on #render" do
+      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+      assert_equal "<h1>Hello World!</h1>\n", template.render
     end
-    assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
-  end
 
-  it 'Renders unsafe HTML when :UNSAFE is set' do
-    template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
-      <<MARKDOWN
+    it "can be rendered more than once" do
+      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+      3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
+    end
+
+    it "smartypants when :smatr is set" do
+      template = Tilt::CommonMarkerTemplate.new(smart: true) do |t|
+        "OKAY -- 'Smarty Pants'"
+      end
+      assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
+    end
+
+    it 'Renders unsafe HTML when :unsafe is set' do
+      template = Tilt::CommonMarkerTemplate.new(unsafe: true) do |_t|
+        <<MARKDOWN
 <div class="alert alert-info full-width">
 <h5 class="card-title">TL;DR</h5>
 <p>This is an unsafe HTML block</p>
@@ -28,9 +29,9 @@ checked_describe 'tilt/commonmarker' do
 
 And then some **other** Markdown
 MARKDOWN
-    end
+      end
 
-    expected = <<EXPECTED_HTML
+      expected = <<EXPECTED_HTML
 <div class="alert alert-info full-width">
 <h5 class="card-title">TL;DR</h5>
 <p>This is an unsafe HTML block</p>
@@ -38,10 +39,58 @@ MARKDOWN
 <p>And then some <strong>other</strong> Markdown</p>
 EXPECTED_HTML
 
-    assert_match(expected, template.render)
-  end
+      assert_match(expected, template.render)
+    end
 
-  it "sets allows_script metadata set to false" do
-    assert_equal false, Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }.metadata[:allows_script]
+    it "autolinking when :autolink is set" do
+      template = Tilt::CommonMarkerTemplate.new(autolink: true) do |t|
+        "https://example.com"
+      end
+      assert_match('<a href="https://example.com">https://example.com</a>', template.render)
+    end
+  else
+    it "preparing and evaluating templates on #render" do
+      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+      assert_equal "<h1>Hello World!</h1>\n", template.render
+    end
+
+    it "can be rendered more than once" do
+      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+      3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
+    end
+
+    it "smartypants when :smartypants is set" do
+      template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
+        "OKAY -- 'Smarty Pants'"
+      end
+      assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
+    end
+
+    it 'Renders unsafe HTML when :UNSAFE is set' do
+      template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
+        <<MARKDOWN
+<div class="alert alert-info full-width">
+<h5 class="card-title">TL;DR</h5>
+<p>This is an unsafe HTML block</p>
+</div>
+
+And then some **other** Markdown
+MARKDOWN
+      end
+
+      expected = <<EXPECTED_HTML
+<div class="alert alert-info full-width">
+<h5 class="card-title">TL;DR</h5>
+<p>This is an unsafe HTML block</p>
+</div>
+<p>And then some <strong>other</strong> Markdown</p>
+EXPECTED_HTML
+
+      assert_match(expected, template.render)
+    end
+
+    it "sets allows_script metadata set to false" do
+      assert_equal false, Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }.metadata[:allows_script]
+    end
   end
 end

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -1,53 +1,8 @@
 require_relative 'test_helper'
 
 checked_describe 'tilt/commonmarker' do
-  if ENV['LATEST_COMMONMARKER'] == 'yes'
-    it "preparing and evaluating templates on #render" do
-      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-      assert_equal "<h1>Hello World!</h1>\n", template.render
-    end
-
-    it "can be rendered more than once" do
-      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-      3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
-    end
-
-    it "smartypants when :smatr is set" do
-      template = Tilt::CommonMarkerTemplate.new(smart: true) do |t|
-        "OKAY -- 'Smarty Pants'"
-      end
-      assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
-    end
-
-    it 'Renders unsafe HTML when :unsafe is set' do
-      template = Tilt::CommonMarkerTemplate.new(unsafe: true) do |_t|
-        <<MARKDOWN
-<div class="alert alert-info full-width">
-<h5 class="card-title">TL;DR</h5>
-<p>This is an unsafe HTML block</p>
-</div>
-
-And then some **other** Markdown
-MARKDOWN
-      end
-
-      expected = <<EXPECTED_HTML
-<div class="alert alert-info full-width">
-<h5 class="card-title">TL;DR</h5>
-<p>This is an unsafe HTML block</p>
-</div>
-<p>And then some <strong>other</strong> Markdown</p>
-EXPECTED_HTML
-
-      assert_match(expected, template.render)
-    end
-
-    it "autolinking when :autolink is set" do
-      template = Tilt::CommonMarkerTemplate.new(autolink: true) do |t|
-        "https://example.com"
-      end
-      assert_match('<a href="https://example.com">https://example.com</a>', template.render)
-    end
+  if defined?(::Commonmarker)
+    # TODO
   else
     it "preparing and evaluating templates on #render" do
       template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }

--- a/test/tilt_commonmarkertemplate_test.rb
+++ b/test/tilt_commonmarkertemplate_test.rb
@@ -1,27 +1,52 @@
 require_relative 'test_helper'
 
 checked_describe 'tilt/commonmarker' do
+  it "preparing and evaluating templates on #render" do
+    template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+    assert_equal "<h1>Hello World!</h1>\n", template.render
+  end
+
+  it "can be rendered more than once" do
+    template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
+    3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
+  end
+
+  it "smartypants when :smartypants is set" do
+    template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
+      "OKAY -- 'Smarty Pants'"
+    end
+    assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
+  end
+
+  it 'Renders unsafe HTML when :UNSAFE is set' do
+    template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
+      <<MARKDOWN
+<div class="alert alert-info full-width">
+<h5 class="card-title">TL;DR</h5>
+<p>This is an unsafe HTML block</p>
+</div>
+
+And then some **other** Markdown
+MARKDOWN
+    end
+
+    expected = <<EXPECTED_HTML
+<div class="alert alert-info full-width">
+<h5 class="card-title">TL;DR</h5>
+<p>This is an unsafe HTML block</p>
+</div>
+<p>And then some <strong>other</strong> Markdown</p>
+EXPECTED_HTML
+
+    assert_match(expected, template.render)
+  end
+
+  it "sets allows_script metadata set to false" do
+    assert_equal false, Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }.metadata[:allows_script]
+  end
+
   if defined?(::Commonmarker)
-    # TODO
-  else
-    it "preparing and evaluating templates on #render" do
-      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-      assert_equal "<h1>Hello World!</h1>\n", template.render
-    end
-
-    it "can be rendered more than once" do
-      template = Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }
-      3.times { assert_equal "<h1>Hello World!</h1>\n", template.render }
-    end
-
-    it "smartypants when :smartypants is set" do
-      template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
-        "OKAY -- 'Smarty Pants'"
-      end
-      assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
-    end
-
-    it 'Renders unsafe HTML when :UNSAFE is set' do
+    it "render unsafe HTML with pre version's option name" do
       template = Tilt::CommonMarkerTemplate.new(UNSAFE: true) do |_t|
         <<MARKDOWN
 <div class="alert alert-info full-width">
@@ -44,8 +69,23 @@ EXPECTED_HTML
       assert_match(expected, template.render)
     end
 
-    it "sets allows_script metadata set to false" do
-      assert_equal false, Tilt::CommonMarkerTemplate.new { |t| "# Hello World!" }.metadata[:allows_script]
+    it "smartypants when :smartypants is set (pre version's option name)" do
+      template = Tilt::CommonMarkerTemplate.new(:smartypants => true) do |t|
+        "OKAY -- 'Smarty Pants'"
+      end
+      assert_match('<p>OKAY – ‘Smarty Pants’</p>', template.render)
+    end
+
+    it "render markdown with custom prefixed-header id" do
+      template = Tilt::CommonMarkerTemplate.new(header_ids: "prefix-") do |t|
+        <<~MARKDOWN
+          # Foo
+        MARKDOWN
+      end
+      expected = <<~HTML
+        <h1><a href="#foo" aria-hidden="true" class="anchor" id="prefix-foo"></a>Foo</h1>
+      HTML
+      assert_match(expected, template.render)
     end
   end
 end


### PR DESCRIPTION
## What
retry of https://github.com/rtomayko/tilt/pull/396

> The Commonmarker gem released v1 incluging breaking api changes.
> https://github.com/gjtorikian/commonmarker/releases/tag/v1.0.0
>
> These changes supports the new commonmarker's api.
>
> To support commonmaker's breaking api changes, tilt gem will release new version including incompatible api change also.
> For notice to tilt gem user, is it better to check commonmarker gem's version?

... and support both of `CommonMaker` (0.x) and `Commonmarker` (1.0.x)