### PR TITLE
Make the rendering of Prawn templates idempotent

### DIFF
--- a/lib/tilt/prawn.rb
+++ b/lib/tilt/prawn.rb
@@ -10,11 +10,10 @@ module Tilt
     def prepare
       @options[:page_size] = 'A4' unless @options.has_key?(:page_size)
       @options[:page_layout] = :portrait unless @options.has_key?(:page_layout)
-      @engine = ::Prawn::Document.new(@options)
     end
     
     def evaluate(scope, locals, &block)
-      pdf = @engine
+      pdf = ::Prawn::Document.new(@options)
       locals = locals.dup
       locals[:pdf] = pdf
       super

--- a/test/tilt_prawntemplate.prawn
+++ b/test/tilt_prawntemplate.prawn
@@ -1,1 +1,2 @@
 pdf.text "Hello Template!"
+pdf.start_new_page

--- a/test/tilt_prawntemplate_test.rb
+++ b/test/tilt_prawntemplate_test.rb
@@ -9,6 +9,10 @@ checked_describe('tilt/prawn', 'pdf-reader') do
     def text
       @reader.pages.map(&:text).join
     end
+
+    def page_count
+      @reader.page_count
+    end
     
     def page_attributes(page_num=1)
       @reader.page(page_num).attributes
@@ -39,7 +43,8 @@ checked_describe('tilt/prawn', 'pdf-reader') do
     template = Tilt::PrawnTemplate.new("test/tilt_prawntemplate.prawn")
     3.times do
       output   = _PdfOutput.new(template.render)
-      assert_includes output.text, "Hello Template!"
+      assert_equal 2, output.page_count
+      assert_equal output.text, "Hello Template!"
     end
   end
   


### PR DESCRIPTION
I noticed that when I reuse a Prawn template to render a PDF,  instead of getting a pristine output, it would render the new PDF on top of the previous one. Because the `Prawn::Document` does not get reset after rendering, it turns into palimpsest.

This change ensures that every render starts with a fresh `Prawn::Document` to avoid this behavior.