### PR TITLE
Remove note about slim fixed locals format

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,6 @@ In ERB templates, you can use the following comment format:
 <%# locals: () %>
 ```
 
-In slim templates, the comment format looks like this:
-
-```
-//# locals: ()
-```
-
 In string templates, it is a little ackward, but still possible (note that the
 closing `}` goes on a separate line:
 


### PR DESCRIPTION
This is already mentioned in `./lib/tilt/slim.rb` and slipped through when rebased - sorry about that.