### PR TITLE
Update Commonmarker option

### DIFF
--- a/lib/tilt/commonmarker.rb
+++ b/lib/tilt/commonmarker.rb
@@ -50,14 +50,24 @@ if defined?(::Commonmarker)
   parse_opts = [
     :smart,
     :default_info_string,
+    :relaxed_tasklist_matching,
+    :relaxed_autolinks,
+    :leave_footnote_definitions,
+    :ignore_setext,
   ].freeze
   render_opts = [
     :hardbreaks,
     :github_pre_lang,
+    :full_info_string,
     :width,
     :unsafe,
     :escape,
     :sourcepos,
+    :escaped_char_spans,
+    :ignore_empty_links,
+    :gfm_quirks,
+    :prefer_fenced,
+    :tasklist_classes,
   ].freeze
   exts = [
     :strikethrough,
@@ -68,9 +78,23 @@ if defined?(::Commonmarker)
     :superscript,
     :header_ids,
     :footnotes,
+    :inline_footnotes,
     :description_lists,
     :front_matter_delimiter,
+    :multiline_block_quotes,
+    :math_dollars,
+    :math_code,
     :shortcodes,
+    :wikilinks_title_before_pipe,
+    :wikilinks_title_after_pipe,
+    :underline,
+    :spoiler,
+    :greentext,
+    :subscript,
+    :subtext,
+    :alerts,
+    :cjk_friendly_emphasis,
+    :highlight,
   ].freeze
 
   Tilt::CommonMarkerTemplate = Tilt::StaticTemplate.subclass do


### PR DESCRIPTION
Hi!

These are the options Tilt currently allows to be passed to the Commonmarker gem:

https://github.com/jeremyevans/tilt/blob/2b1189faba686df872d8d9838c9d482e7c24ea19/lib/tilt/commonmarker.rb#L47-L74

But the Commonmarker gem supports [quite a few more](https://github.com/gjtorikian/commonmarker/blob/24e491ae10d091e18f45817095a6a9b83d252573/lib/commonmarker/config.rb#L7-L58) options than Tilt is currently able to pass on.

I haven't looked much at the Tilt code (other than finding out why my options aren't passed on), so I'm unsure what the best way forward would be.

If I understand it correctly, Tilt::Template has one flat `options` hash, that includes all sorts of options. Those are then parsed out and forwarded to the appropriate receiver.

E.g. keep `:default_encoding`
https://github.com/jeremyevans/tilt/blob/2b1189faba686df872d8d9838c9d482e7c24ea19/lib/tilt/template.rb#L93-L95

but pass others to Commonmarker, such as  `:autolink` as extention option
https://github.com/jeremyevans/tilt/blob/2b1189faba686df872d8d9838c9d482e7c24ea19/lib/tilt/commonmarker.rb#L80

and `:hardbreaks` as render option
https://github.com/jeremyevans/tilt/blob/2b1189faba686df872d8d9838c9d482e7c24ea19/lib/tilt/commonmarker.rb#L79

I guess that "routing" of options is the reason why all keys must be defined in Tilt. So, I currently see no better way than to simply try to keep the options up-to-date with the upstream gem, right?.

Thank you for your hard work on this, I appreciate it a lot!